### PR TITLE
add a generic polygon factory class

### DIFF
--- a/src/geo/CMakeLists.txt
+++ b/src/geo/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(geo OBJECT
         src/GeoTubeArrayFactory.cc
         src/GeoTubeFactory.cc
         src/GeoTubeIntersectionFactory.cc
+        src/GeoGenericPolygonFactory.cc
         src/GeoWaterBoxArrayFactory.cc
         src/Materials.cc
         src/TubeFacetSolid.cc

--- a/src/geo/include/RAT/GeoGenericPolygonFactory.hh
+++ b/src/geo/include/RAT/GeoGenericPolygonFactory.hh
@@ -1,0 +1,15 @@
+#ifndef __RAT_GeoGenericPolygonFactory__
+#define __RAT_GeoGenericPolygonFactory__
+
+#include <RAT/GeoSolidFactory.hh>
+
+namespace RAT {
+class GeoGenericPolygonFactory : public GeoSolidFactory {
+ public:
+  GeoGenericPolygonFactory() : GeoSolidFactory("genpoly"){};
+  virtual G4VSolid *ConstructSolid(DBLinkPtr table);
+};
+
+}  // namespace RAT
+
+#endif

--- a/src/geo/src/GeoBuilder.cc
+++ b/src/geo/src/GeoBuilder.cc
@@ -9,13 +9,13 @@
 #include <RAT/GeoCherenkovSourceFactory.hh>
 #include <RAT/GeoConvexLensFactory.hh>
 #include <RAT/GeoCutTubeFactory.hh>
+#include <RAT/GeoGenericPolygonFactory.hh>
 #include <RAT/GeoLensFactory.hh>
 #include <RAT/GeoPerfBoxFactory.hh>
 #include <RAT/GeoPerfSphereFactory.hh>
 #include <RAT/GeoPerfTubeFactory.hh>
 #include <RAT/GeoPolyArrayFactory.hh>
 #include <RAT/GeoPolygonFactory.hh>
-#include <RAT/GeoGenericPolygonFactory.hh>
 #include <RAT/GeoReflectorFactory.hh>
 #include <RAT/GeoReflectorWaveguideFactory.hh>
 #include <RAT/GeoRevArrayFactory.hh>

--- a/src/geo/src/GeoBuilder.cc
+++ b/src/geo/src/GeoBuilder.cc
@@ -15,6 +15,7 @@
 #include <RAT/GeoPerfTubeFactory.hh>
 #include <RAT/GeoPolyArrayFactory.hh>
 #include <RAT/GeoPolygonFactory.hh>
+#include <RAT/GeoGenericPolygonFactory.hh>
 #include <RAT/GeoReflectorFactory.hh>
 #include <RAT/GeoReflectorWaveguideFactory.hh>
 #include <RAT/GeoRevArrayFactory.hh>
@@ -61,6 +62,7 @@ GeoBuilder::GeoBuilder() {
   new GeoPerfBoxFactory();
   new GeoCutTubeFactory();
   new GeoPolyArrayFactory();
+  new GeoGenericPolygonFactory();
   new WLSPFactory();
   new WLSPCoverFactory();
 

--- a/src/geo/src/GeoGenericPolygonFactory.cc
+++ b/src/geo/src/GeoGenericPolygonFactory.cc
@@ -1,0 +1,62 @@
+#include <CLHEP/Units/PhysicalConstants.h>
+#include <CLHEP/Units/SystemOfUnits.h>
+
+#include <G4ExtrudedSolid.hh>
+#include <G4SubtractionSolid.hh>
+#include <G4TwoVector.hh>
+#include <RAT/GeoGenericPolygonFactory.hh>
+#include <RAT/PolygonOrientation.hh>
+
+#include <vector>
+#include <string>
+
+namespace RAT {
+
+G4VSolid *GeoGenericPolygonFactory::ConstructSolid(DBLinkPtr table) {
+  std::string volume_name = table->GetIndex();
+  const G4double size_z = table->GetD("size_z") * CLHEP::mm;  // half thickness of plate
+
+  // Define the base polygon verticies
+  std::vector<G4TwoVector> polygon;
+  std::string poly_table_name = table->GetS("poly_table");
+  DBLinkPtr lpoly_table = DB::Get()->GetLink(poly_table_name);
+  const std::vector<G4double> &vertex_pnts_x = lpoly_table->GetDArray("x");
+  const std::vector<G4double> &vertex_pnts_y = lpoly_table->GetDArray("y");
+  for ( G4int i = 0, n = G4int(vertex_pnts_x.size()); i < n; ++i ) {
+    polygon.push_back(G4TwoVector(vertex_pnts_x[i] * CLHEP::mm,
+                                  vertex_pnts_y[i] * CLHEP::mm));
+  }
+
+  // Define polygons to subtract fro the base polygon
+  std::vector<std::vector<G4TwoVector>> subpolygons;
+  const int n_subpolygon = table->GetI("n_subpolygon");
+  for ( int i=1; i<=n_subpolygon; ++i ) {
+    //const std::string subpolygon_link_name = std::format("subpolygon_table_{}", i);
+    std::string subpolygon_link_name = std::string("subpolygon_table_")+std::to_string(i);
+    std::string subpolygon_table_name = table->GetS(subpolygon_link_name);
+    DBLinkPtr table = DB::Get()->GetLink(subpolygon_table_name);
+    const std::vector<G4double>& pnts_x = table->GetDArray("x");
+    const std::vector<G4double>& pnts_y = table->GetDArray("y");
+    std::vector<G4TwoVector> subpolygon;
+    for ( G4int i = 0, n = G4int(pnts_x.size()); i < n; ++i) {
+      subpolygon.push_back(G4TwoVector(pnts_x[i] * CLHEP::mm,
+                                    pnts_y[i] * CLHEP::mm));
+    }
+    subpolygons.push_back(subpolygon);
+  }
+
+  // Build the base solid
+  G4TwoVector zero_offset(0,0);
+
+  G4VSolid* base_solid = new G4ExtrudedSolid(volume_name, polygon, size_z/2, zero_offset, 1, zero_offset, 1);
+
+  // Subtract polygons
+  for ( auto subpoly : subpolygons ) {
+    G4ExtrudedSolid sub_solid(volume_name + "_sub_solid", subpoly, size_z/2, zero_offset, 1, zero_offset, 1);
+    base_solid = new G4SubtractionSolid(volume_name, base_solid, &sub_solid, 0, G4ThreeVector(0.0, 0.0, 0.0));
+  }
+
+  return base_solid;
+}
+
+}  // namespace RAT

--- a/src/geo/src/GeoGenericPolygonFactory.cc
+++ b/src/geo/src/GeoGenericPolygonFactory.cc
@@ -52,8 +52,9 @@ G4VSolid *GeoGenericPolygonFactory::ConstructSolid(DBLinkPtr table) {
 
   // Subtract polygons
   for ( auto subpoly : subpolygons ) {
-    G4ExtrudedSolid sub_solid(volume_name + "_sub_solid", subpoly, size_z/2, zero_offset, 1, zero_offset, 1);
-    base_solid = new G4SubtractionSolid(volume_name, base_solid, &sub_solid, 0, G4ThreeVector(0.0, 0.0, 0.0));
+    // Note: the height is changed to size_z/2 -> size_z to clearly cut out
+    G4VSolid* sub_solid = new G4ExtrudedSolid(volume_name + "_sub_solid", subpoly, size_z, zero_offset, 1, zero_offset, 1);
+    base_solid = new G4SubtractionSolid(volume_name, base_solid, sub_solid, 0, G4ThreeVector(0.0, 0.0, 0.0));
   }
 
   return base_solid;

--- a/src/geo/src/GeoGenericPolygonFactory.cc
+++ b/src/geo/src/GeoGenericPolygonFactory.cc
@@ -44,13 +44,13 @@ G4VSolid* GeoGenericPolygonFactory::ConstructSolid(DBLinkPtr table) {
   // Build the base solid
   G4TwoVector zero_offset(0, 0);
 
-  G4VSolid* base_solid = new G4ExtrudedSolid(volume_name, polygon, size_z / 2, zero_offset, 1, zero_offset, 1);
+  G4VSolid* base_solid = new G4ExtrudedSolid(volume_name, polygon, size_z, zero_offset, 1, zero_offset, 1);
 
   // Subtract polygons
   for (auto subpoly : subpolygons) {
-    // Note: the height is changed to size_z/2 -> size_z to clearly cut out
+    // Note: the height is changed to size_z -> 2*size_z to clearly cut out
     G4VSolid* sub_solid =
-        new G4ExtrudedSolid(volume_name + "_sub_solid", subpoly, size_z, zero_offset, 1, zero_offset, 1);
+        new G4ExtrudedSolid(volume_name + "_sub_solid", subpoly, 2 * size_z, zero_offset, 1, zero_offset, 1);
     base_solid = new G4SubtractionSolid(volume_name, base_solid, sub_solid, 0, G4ThreeVector(0.0, 0.0, 0.0));
   }
 

--- a/src/geo/src/GeoGenericPolygonFactory.cc
+++ b/src/geo/src/GeoGenericPolygonFactory.cc
@@ -6,13 +6,12 @@
 #include <G4TwoVector.hh>
 #include <RAT/GeoGenericPolygonFactory.hh>
 #include <RAT/PolygonOrientation.hh>
-
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace RAT {
 
-G4VSolid *GeoGenericPolygonFactory::ConstructSolid(DBLinkPtr table) {
+G4VSolid* GeoGenericPolygonFactory::ConstructSolid(DBLinkPtr table) {
   std::string volume_name = table->GetIndex();
   const G4double size_z = table->GetD("size_z") * CLHEP::mm;  // half thickness of plate
 
@@ -20,40 +19,38 @@ G4VSolid *GeoGenericPolygonFactory::ConstructSolid(DBLinkPtr table) {
   std::vector<G4TwoVector> polygon;
   std::string poly_table_name = table->GetS("poly_table");
   DBLinkPtr lpoly_table = DB::Get()->GetLink(poly_table_name);
-  const std::vector<G4double> &vertex_pnts_x = lpoly_table->GetDArray("x");
-  const std::vector<G4double> &vertex_pnts_y = lpoly_table->GetDArray("y");
-  for ( G4int i = 0, n = G4int(vertex_pnts_x.size()); i < n; ++i ) {
-    polygon.push_back(G4TwoVector(vertex_pnts_x[i] * CLHEP::mm,
-                                  vertex_pnts_y[i] * CLHEP::mm));
+  const std::vector<G4double>& vertex_pnts_x = lpoly_table->GetDArray("x");
+  const std::vector<G4double>& vertex_pnts_y = lpoly_table->GetDArray("y");
+  for (G4int i = 0, n = G4int(vertex_pnts_x.size()); i < n; ++i) {
+    polygon.push_back(G4TwoVector(vertex_pnts_x[i] * CLHEP::mm, vertex_pnts_y[i] * CLHEP::mm));
   }
 
   // Define polygons to subtract fro the base polygon
   std::vector<std::vector<G4TwoVector>> subpolygons;
   const int n_subpolygon = table->GetI("n_subpolygon");
-  for ( int i=1; i<=n_subpolygon; ++i ) {
-    //const std::string subpolygon_link_name = std::format("subpolygon_table_{}", i);
-    std::string subpolygon_link_name = std::string("subpolygon_table_")+std::to_string(i);
-    std::string subpolygon_table_name = table->GetS(subpolygon_link_name);
+  for (int i = 1; i <= n_subpolygon; ++i) {
+    const std::string subpolygon_link_name = "subpolygon_table_" + std::to_string(i);
+    const std::string subpolygon_table_name = table->GetS(subpolygon_link_name);
     DBLinkPtr table = DB::Get()->GetLink(subpolygon_table_name);
     const std::vector<G4double>& pnts_x = table->GetDArray("x");
     const std::vector<G4double>& pnts_y = table->GetDArray("y");
     std::vector<G4TwoVector> subpolygon;
-    for ( G4int i = 0, n = G4int(pnts_x.size()); i < n; ++i) {
-      subpolygon.push_back(G4TwoVector(pnts_x[i] * CLHEP::mm,
-                                    pnts_y[i] * CLHEP::mm));
+    for (G4int i = 0, n = G4int(pnts_x.size()); i < n; ++i) {
+      subpolygon.push_back(G4TwoVector(pnts_x[i] * CLHEP::mm, pnts_y[i] * CLHEP::mm));
     }
     subpolygons.push_back(subpolygon);
   }
 
   // Build the base solid
-  G4TwoVector zero_offset(0,0);
+  G4TwoVector zero_offset(0, 0);
 
-  G4VSolid* base_solid = new G4ExtrudedSolid(volume_name, polygon, size_z/2, zero_offset, 1, zero_offset, 1);
+  G4VSolid* base_solid = new G4ExtrudedSolid(volume_name, polygon, size_z / 2, zero_offset, 1, zero_offset, 1);
 
   // Subtract polygons
-  for ( auto subpoly : subpolygons ) {
+  for (auto subpoly : subpolygons) {
     // Note: the height is changed to size_z/2 -> size_z to clearly cut out
-    G4VSolid* sub_solid = new G4ExtrudedSolid(volume_name + "_sub_solid", subpoly, size_z, zero_offset, 1, zero_offset, 1);
+    G4VSolid* sub_solid =
+        new G4ExtrudedSolid(volume_name + "_sub_solid", subpoly, size_z, zero_offset, 1, zero_offset, 1);
     base_solid = new G4SubtractionSolid(volume_name, base_solid, sub_solid, 0, G4ThreeVector(0.0, 0.0, 0.0));
   }
 


### PR DESCRIPTION
Add a generic polygon factory class for the geometry, implemented using the G4Extruded.

User has to provide poly_table separately.

To subtract polygon(s), set `n_subpolygon` to some value and `subpolygon_table_1`, etc. the index of subtraction polygon table name starts from `1`.

Example usage:
```
{
  name: "GEO",
  index: "target_bar5",
  enable: 1,
  valid_begin: [0,0],
  valid_end: [0,0],
  mother: "gc_ls",
  type: "genpoly",
  n_subpolygon: 2,
  size_z: 10.0,
  poly_table: "AS_shape",
  subpolygon_table_1: "AS_window1_shape",
  subpolygon_table_2: "AS_window2_shape",
  position: [0.0, 0.0, 598.0],
  rotation: [0.0, 0.0, 90.0],
  material: "acrylic_RENE",
  color: [0.2,0.2,0.2,0.05],
  drawstyle: "solid",
}
```

#2 